### PR TITLE
use the closer interface to resources that must be closed

### DIFF
--- a/pkg/mcast/core/reliable_transport.go
+++ b/pkg/mcast/core/reliable_transport.go
@@ -104,11 +104,9 @@ func (r *ReliableTransport) Listen() <-chan types.Message {
 }
 
 // ReliableTransport implements Transport interface.
-func (r *ReliableTransport) Close() {
+func (r *ReliableTransport) Close() error {
 	r.finish()
-	if err := r.relt.Close(); err != nil {
-		r.log.Errorf("failed stopping reliableTransport. %#v", err)
-	}
+	return r.relt.Close()
 }
 
 // This method will keep polling until

--- a/pkg/mcast/core/transport.go
+++ b/pkg/mcast/core/transport.go
@@ -2,11 +2,14 @@ package core
 
 import (
 	"github.com/jabolina/go-mcast/pkg/mcast/types"
+	"io"
 )
 
 // The reliableTransport interface providing the communication
 // primitives by the protocol.
 type Transport interface {
+	io.Closer
+
 	// Reliably deliver the message to all correct processes
 	// in the same order.
 	Broadcast(message types.Message) error
@@ -19,7 +22,4 @@ type Transport interface {
 
 	// Listen for messages that arrives on the reliableTransport.
 	Listen() <-chan types.Message
-
-	// Close the reliableTransport for sending and receiving messages.
-	Close()
 }

--- a/pkg/mcast/core/unreliable_transport.go
+++ b/pkg/mcast/core/unreliable_transport.go
@@ -88,9 +88,9 @@ func (u *UnreliableTransport) Listen() <-chan types.Message {
 	return u.producer
 }
 
-func (u *UnreliableTransport) Close() {
+func (u *UnreliableTransport) Close() error {
 	u.cancel()
-	u.comm.Close()
+	return u.comm.Close()
 }
 
 func (u *UnreliableTransport) poll() {

--- a/pkg/mcast/multicast.go
+++ b/pkg/mcast/multicast.go
@@ -56,8 +56,7 @@ func NewGenericMulticast(configuration *types.Configuration) (IMulticast, error)
 }
 
 func (m *Multicast) Close() error {
-	m.peer.Stop()
-	return nil
+	return m.peer.Close()
 }
 
 func (m *Multicast) Write(request types.Request) error {

--- a/pkg/mcast/types/configuration.go
+++ b/pkg/mcast/types/configuration.go
@@ -16,6 +16,7 @@ var (
 	ErrStorage              = errors.New("storage cannot be nil")
 	ErrLogger               = errors.New("logger cannot be nil")
 	ErrOracle               = errors.New("oracle cannot be nil")
+	ErrInvalidTimeout       = errors.New("invalid timeout value")
 )
 
 // Holds the peer configuration.
@@ -111,6 +112,10 @@ func (c Configuration) IsValid() error {
 
 	if c.Version < 0 || c.Version > LatestProtocolVersion {
 		return ErrInvalidVersion
+	}
+
+	if c.DefaultTimeout <= 0 {
+		return ErrInvalidTimeout
 	}
 
 	if c.Conflict == nil {

--- a/test/testing.go
+++ b/test/testing.go
@@ -30,9 +30,11 @@ func (t *TestInvoker) Spawn(f func()) {
 	}()
 }
 
-func (t *TestInvoker) Stop() {
+func (t *TestInvoker) Close() error {
 	t.group.Wait()
+	return nil
 }
+
 func NewInvoker() core.Invoker {
 	return &TestInvoker{
 		group: &sync.WaitGroup{},

--- a/test/unity.go
+++ b/test/unity.go
@@ -114,7 +114,7 @@ func (p *PeerUnity) Shutdown() {
 	for _, peer := range p.Peers {
 		peer.Close()
 	}
-	p.Invoker.Stop()
+	p.Invoker.Close()
 }
 
 // Implements the Unity interface.


### PR DESCRIPTION
Some of the interfaces did have a `Close`, `Stop` or `Shutdown` methods 
to finish any resources, goroutines, etc. But they were not using the
`io.Closer` interface. This is just a minor change so these resources
implement the interface now.