### PR TITLE
[test] test improvements

### DIFF
--- a/fuzzy/broadcast_test.go
+++ b/fuzzy/broadcast_test.go
@@ -1,7 +1,7 @@
 package fuzzy
 
 import (
-	"github.com/jabolina/go-mcast/test"
+	"github.com/jabolina/go-mcast/test/util"
 	"go.uber.org/goleak"
 	"log"
 	"sync"
@@ -20,11 +20,11 @@ func Test_BroadcastSequentialCommands(t *testing.T) {
 	partition2 := []int{24003, 24004, 24005}
 	partition3 := []int{24006, 24007, 24008}
 	ports := [][]int{partition1, partition2, partition3}
-	cluster := test.CreateCluster("alphabet", ports, t)
+	cluster := util.CreateCluster("alphabet", ports, t)
 	defer func() {
-		if !test.WaitThisOrTimeout(cluster.Off, 30*time.Second) {
+		if !util.WaitThisOrTimeout(cluster.Off, 30*time.Second) {
 			t.Error("failed shutdown cluster")
-			test.PrintStackTrace(t)
+			util.PrintStackTrace(t)
 		}
 	}()
 
@@ -39,7 +39,7 @@ func Test_BroadcastSequentialCommands(t *testing.T) {
 				if !res.Success {
 					t.Errorf("response with error %s. %#v", res.Failure.Error(), res.Data)
 				}
-			case <-time.After(test.DefaultTestTimeout):
+			case <-time.After(util.DefaultTestTimeout):
 				t.Log("stop listening unity.")
 				return
 			}
@@ -47,9 +47,9 @@ func Test_BroadcastSequentialCommands(t *testing.T) {
 	}
 
 	go listener()
-	for _, letter := range test.Alphabet {
+	for _, letter := range util.Alphabet {
 		log.Printf("************************** sending %s **************************", letter)
-		req := test.GenerateRequest([]byte(letter), cluster.Names)
+		req := util.GenerateRequest([]byte(letter), cluster.Names)
 		if err := cluster.Next().Write(req); err != nil {
 			t.Errorf("failed writting request %v", err)
 		}
@@ -65,11 +65,11 @@ func Test_BroadcastConcurrentCommands(t *testing.T) {
 	partition2 := []int{20003, 20004, 20005}
 	partition3 := []int{20006, 20007, 20008}
 	ports := [][]int{partition1, partition2, partition3}
-	cluster := test.CreateCluster("concurrent", ports, t)
+	cluster := util.CreateCluster("concurrent", ports, t)
 	defer func() {
-		if !test.WaitThisOrTimeout(cluster.Off, 30*time.Second) {
+		if !util.WaitThisOrTimeout(cluster.Off, 30*time.Second) {
 			t.Error("failed shutdown cluster")
-			test.PrintStackTrace(t)
+			util.PrintStackTrace(t)
 		}
 	}()
 
@@ -84,7 +84,7 @@ func Test_BroadcastConcurrentCommands(t *testing.T) {
 				if !res.Success {
 					t.Errorf("response with error %s. %#v", res.Failure.Error(), res.Data)
 				}
-			case <-time.After(test.DefaultTestTimeout):
+			case <-time.After(util.DefaultTestTimeout):
 				t.Log("stop listening unity.")
 				return
 			}
@@ -95,19 +95,19 @@ func Test_BroadcastConcurrentCommands(t *testing.T) {
 	write := func(idx int, val string) {
 		defer wg.Done()
 		log.Printf("************************** sending %s **************************", val)
-		req := test.GenerateRequest([]byte(val), cluster.Names)
+		req := util.GenerateRequest([]byte(val), cluster.Names)
 		if err := cluster.Next().Write(req); err != nil {
 			t.Errorf("failed writting request %v", err)
 		}
 	}
 
-	sample := test.Alphabet
+	sample := util.Alphabet
 	wg.Add(len(sample))
 	for i, content := range sample {
 		go write(i, content)
 	}
 
-	if !test.WaitThisOrTimeout(wg.Wait, 30*time.Second) {
+	if !util.WaitThisOrTimeout(wg.Wait, 30*time.Second) {
 		t.Errorf("not finished all after 30 seconds!")
 	}
 	cluster.DoesAllClusterMatch()

--- a/fuzzy/generic_test.go
+++ b/fuzzy/generic_test.go
@@ -3,7 +3,7 @@ package fuzzy
 import (
 	"fmt"
 	"github.com/jabolina/go-mcast/pkg/mcast/types"
-	"github.com/jabolina/go-mcast/test"
+	"github.com/jabolina/go-mcast/test/util"
 	"go.uber.org/goleak"
 	"log"
 	"sync"
@@ -23,12 +23,12 @@ func Test_ShouldMaintainConsistencyWhenSyncGeneric(t *testing.T) {
 	partition2 := []int{21003, 21004, 21005}
 	partition3 := []int{21006, 21007, 21008}
 	ports := [][]int{partition1, partition2, partition3}
-	cluster := test.CreateClusterConflict("generic-sync", &ConflictWhenNeeded{}, ports, t)
+	cluster := util.CreateClusterConflict("generic-sync", &ConflictWhenNeeded{}, ports, t)
 	testSize := 50
 	defer func() {
-		if !test.WaitThisOrTimeout(cluster.Off, 30*time.Second) {
+		if !util.WaitThisOrTimeout(cluster.Off, 30*time.Second) {
 			t.Error("failed shutdown cluster")
-			test.PrintStackTrace(t)
+			util.PrintStackTrace(t)
 		}
 	}()
 
@@ -55,7 +55,7 @@ func Test_ShouldMaintainConsistencyWhenSyncGeneric(t *testing.T) {
 		content := fmt.Sprintf("msg-%d", i)
 		data := []byte(content)
 		log.Printf("************************** sending [%s] **************************", content)
-		req := test.GenerateRequest(data, cluster.Names)
+		req := util.GenerateRequest(data, cluster.Names)
 		if i&0x1 == 0 {
 			req.Extra = []byte(fmt.Sprintf("generic-%d", i))
 		}
@@ -74,12 +74,12 @@ func Test_ShouldMaintainConsistencyWhenAsyncGeneric(t *testing.T) {
 	partition2 := []int{23003, 23004, 23005}
 	partition3 := []int{23006, 23007, 23008}
 	ports := [][]int{partition1, partition2, partition3}
-	cluster := test.CreateClusterConflict("generic-async", &ConflictWhenNeeded{}, ports, t)
+	cluster := util.CreateClusterConflict("generic-async", &ConflictWhenNeeded{}, ports, t)
 	testSize := 50
 	defer func() {
-		if !test.WaitThisOrTimeout(cluster.Off, 30*time.Second) {
+		if !util.WaitThisOrTimeout(cluster.Off, 30*time.Second) {
 			t.Error("failed shutdown cluster")
-			test.PrintStackTrace(t)
+			util.PrintStackTrace(t)
 		}
 	}()
 
@@ -103,7 +103,7 @@ func Test_ShouldMaintainConsistencyWhenAsyncGeneric(t *testing.T) {
 	write := func(idx int, val string) {
 		defer wg.Done()
 		log.Printf("************************** sending [%s] **************************", val)
-		req := test.GenerateRequest([]byte(val), cluster.Names)
+		req := util.GenerateRequest([]byte(val), cluster.Names)
 		if idx&0x1 == 0 {
 			req.Extra = []byte(fmt.Sprintf("generic-%d", idx))
 		}
@@ -118,7 +118,7 @@ func Test_ShouldMaintainConsistencyWhenAsyncGeneric(t *testing.T) {
 		go write(i, fmt.Sprintf("msg-%d", i))
 	}
 
-	if !test.WaitThisOrTimeout(wg.Wait, 30*time.Second) {
+	if !util.WaitThisOrTimeout(wg.Wait, 30*time.Second) {
 		t.Errorf("not finished all after 30 seconds!")
 	}
 	cluster.DoesAllClusterMatch()

--- a/fuzzy/generic_test.go
+++ b/fuzzy/generic_test.go
@@ -94,7 +94,7 @@ func Test_ShouldMaintainConsistencyWhenAsyncGeneric(t *testing.T) {
 				if !res.Success {
 					t.Errorf("response with error %s. %#v", res.Failure.Error(), res.Data)
 				}
-			case <-time.After(5 * time.Second):
+			case <-time.After(util.DefaultTestTimeout):
 				t.Log("stop listening unity.")
 				return
 			}

--- a/fuzzy/multicast_test.go
+++ b/fuzzy/multicast_test.go
@@ -67,7 +67,7 @@ func Test_MulticastMessagesConcurrently(t *testing.T) {
 	}
 
 	wg.Wait()
-	time.Sleep(time.Second)
+	time.Sleep(util.DefaultTestTimeout)
 
 	util.CompareOutputs(t, []util.Unity{first, second}, func(data types.DataHolder) bool {
 		return bytes.Equal(data.Extensions, ab)

--- a/fuzzy/multicast_test.go
+++ b/fuzzy/multicast_test.go
@@ -1,60 +1,19 @@
 package fuzzy
 
 import (
+	"bytes"
+	"github.com/jabolina/go-mcast/pkg/mcast/helper"
 	"github.com/jabolina/go-mcast/pkg/mcast/types"
-	"github.com/jabolina/go-mcast/test"
+	"github.com/jabolina/go-mcast/test/util"
 	"go.uber.org/goleak"
 	"sync"
 	"testing"
 	"time"
 )
 
-// Will try send commands sequentially to different partitions.
-// This will verify if the commands are still delivered in the same
-// order across different partitions.
-func Test_MulticastSequentialCommands(t *testing.T) {
-	defer goleak.VerifyNone(t)
-
-	partition1 := []int{25000, 25001, 25002}
-	partition2 := []int{25003, 25004, 25005}
-	partition3 := []int{25006, 25007, 25008}
-
-	partitionA := test.ProperPartitionName("mcast-sync-a", partition1)
-	partitionB := test.ProperPartitionName("mcast-sync-b", partition2)
-	partitionC := test.ProperPartitionName("mcast-sync-c", partition3)
-
-	first := test.CreateUnity(partitionA, partition1, t)
-	second := test.CreateUnity(partitionB, partition2, t)
-	third := test.CreateUnity(partitionC, partition3, t)
-
-	defer first.Shutdown()
-	defer second.Shutdown()
-	defer third.Shutdown()
-
-	broadcast := test.GenerateRequest([]byte("broadcast"), []types.Partition{partitionA, partitionB, partitionC})
-	err := first.Write(broadcast)
-	if err != nil {
-		t.Errorf("failed broadcasting first message. %#v", err)
-	}
-
-	onlySomePartitions := test.GenerateRequest([]byte("secret"), []types.Partition{partitionB, partitionC})
-	err = second.Write(onlySomePartitions)
-	if err != nil {
-		t.Errorf("failed sending to some partitions. %#v", err)
-	}
-
-	time.Sleep(time.Second)
-	truth := second.Read()
-	if !truth.Success {
-		t.Errorf("failed reading values. %#v", truth.Failure)
-	}
-
-	test.DoWeMatch(truth.Data, []test.Unity{second, third}, t)
-}
-
 // Will send commands to different partitions concurrently.
 // After sending commands concurrently, commands should be accepted in
-// the same order.
+// the same order across partitions.
 func Test_MulticastMessagesConcurrently(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
@@ -62,49 +21,63 @@ func Test_MulticastMessagesConcurrently(t *testing.T) {
 	partition2 := []int{26003, 26004, 26005}
 	partition3 := []int{26006, 26007, 26008}
 
-	partitionA := test.ProperPartitionName("mcast-async-a", partition1)
-	partitionB := test.ProperPartitionName("mcast-async-b", partition2)
-	partitionC := test.ProperPartitionName("mcast-async-c", partition3)
+	partitionA := util.ProperPartitionName("mcast-async-a", partition1)
+	partitionB := util.ProperPartitionName("mcast-async-b", partition2)
+	partitionC := util.ProperPartitionName("mcast-async-c", partition3)
 
-	first := test.CreateUnity(partitionA, partition1, t)
-	second := test.CreateUnity(partitionB, partition2, t)
-	third := test.CreateUnity(partitionC, partition3, t)
+	first := util.CreateUnity(partitionA, partition1, t)
+	second := util.CreateUnity(partitionB, partition2, t)
+	third := util.CreateUnity(partitionC, partition3, t)
 
-	wait := &sync.WaitGroup{}
+	sampleSize := 10
+
+	wg := &sync.WaitGroup{}
 
 	defer first.Shutdown()
 	defer second.Shutdown()
 	defer third.Shutdown()
 
-	wait.Add(2)
+	ab := []byte("AB")
+	bc := []byte("BC")
+	ac := []byte("AC")
 
-	sendBroadcast := func() {
-		defer wait.Done()
-		broadcast := test.GenerateRequest([]byte("broadcast"), []types.Partition{partitionA, partitionB, partitionC})
-		err := first.Write(broadcast)
+	sendBroadcast := func(unity util.Unity, extra []byte, partitions []types.Partition) {
+		defer wg.Done()
+		broadcast := util.GenerateRequest([]byte(helper.GenerateUID()), partitions)
+		broadcast.Extra = extra
+		err := unity.Write(broadcast)
 		if err != nil {
-			t.Errorf("failed broadcasting first message. %#v", err)
+			t.Errorf("failed sending message to %v. %#v", partitions, err)
 		}
 	}
 
-	sendMulticast := func() {
-		defer wait.Done()
-		onlySomePartitions := test.GenerateRequest([]byte("secret"), []types.Partition{partitionB, partitionC})
-		err := second.Write(onlySomePartitions)
-		if err != nil {
-			t.Errorf("failed sending to some partitions. %#v", err)
-		}
+	wg.Add(sampleSize)
+	for i := 0; i < sampleSize; i++ {
+		go sendBroadcast(first, ab, []types.Partition{partitionA, partitionB})
 	}
 
-	go sendBroadcast()
-	go sendMulticast()
+	wg.Add(sampleSize)
+	for i := 0; i < sampleSize; i++ {
+		go sendBroadcast(second, bc, []types.Partition{partitionB, partitionC})
+	}
 
-	wait.Wait()
+	wg.Add(sampleSize)
+	for i := 0; i < sampleSize; i++ {
+		go sendBroadcast(third, ac, []types.Partition{partitionA, partitionC})
+	}
+
+	wg.Wait()
 	time.Sleep(time.Second)
-	truth := second.Read()
-	if !truth.Success {
-		t.Errorf("failed reading values. %#v", truth.Failure)
-	}
 
-	test.DoWeMatch(truth.Data, []test.Unity{second, third}, t)
+	util.CompareOutputs(t, []util.Unity{first, second}, func(data types.DataHolder) bool {
+		return bytes.Equal(data.Extensions, ab)
+	})
+
+	util.CompareOutputs(t, []util.Unity{second, third}, func(data types.DataHolder) bool {
+		return bytes.Equal(data.Extensions, bc)
+	})
+
+	util.CompareOutputs(t, []util.Unity{first, third}, func(data types.DataHolder) bool {
+		return bytes.Equal(data.Extensions, ac)
+	})
 }

--- a/fuzzy/temporal_test.go
+++ b/fuzzy/temporal_test.go
@@ -1,0 +1,192 @@
+package fuzzy
+
+import (
+	"bytes"
+	"github.com/jabolina/go-mcast/pkg/mcast/helper"
+	"github.com/jabolina/go-mcast/pkg/mcast/types"
+	"github.com/jabolina/go-mcast/test/util"
+	"go.uber.org/goleak"
+	"sync"
+	"testing"
+	"time"
+)
+
+// If a correct process GM-Cast a message `m` to `m.dest`, then
+// some process in `m.dest` eventually GM-Deliver `m`.
+func Test_ValidityProperty(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	partition1 := []int{21200, 21201, 21202}
+	partition2 := []int{21203, 21204, 21205}
+	partition3 := []int{21206, 21207, 21208}
+
+	ports := [][]int{partition1, partition2, partition3}
+
+	cluster := util.CreateCluster("validity", ports, t)
+	defer func() {
+		if !util.WaitThisOrTimeout(cluster.Off, 30*time.Second) {
+			t.Error("failed shutdown cluster")
+			util.PrintStackTrace(t)
+		}
+	}()
+
+	gmDeliver := make(chan interface{})
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	listener := func() {
+		defer wg.Done()
+		select {
+		case res := <-cluster.Next().Listen():
+			if !res.Success {
+				t.Errorf("response with error %s. %#v", res.Failure.Error(), res.Data)
+			}
+			gmDeliver <- true
+		case <-time.After(util.DefaultTestTimeout):
+			t.Log("stop listening unity.")
+		}
+	}
+
+	go listener()
+	req := util.GenerateRequest([]byte("ehlo"), cluster.Names)
+	if err := cluster.Next().Write(req); err != nil {
+		t.Errorf("failed writting request %v", err)
+	}
+
+	select {
+	case <-gmDeliver:
+	case <-time.After(util.DefaultTestTimeout):
+		t.Errorf("did not eventually delivered")
+	}
+
+	wg.Wait()
+}
+
+// Agreement states that:
+// If a correct process GM-Deliver a message `m`, then all correct
+// processes in `m.dest` eventually GM-Deliver `m`.
+//
+// And Integrity:
+// For any message `m`, every correct process in `m.dest` GM-Deliver
+// `m` at most once, and only if `m` was previously GM-Cast by some process.
+func Test_AgreementAndIntegrityProperty(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	partition1 := []int{16100, 16101, 16102}
+	partition2 := []int{16103, 16104, 16105}
+	partition3 := []int{16106, 16107, 16108}
+
+	partitionA := util.ProperPartitionName("agreement-a", partition1)
+	partitionB := util.ProperPartitionName("agreement-b", partition2)
+	partitionC := util.ProperPartitionName("agreement-c", partition3)
+	partitions := []types.Partition{partitionA, partitionB, partitionC}
+
+	first := util.CreateUnity(partitionA, partition1, t)
+	second := util.CreateUnity(partitionB, partition2, t)
+	third := util.CreateUnity(partitionC, partition3, t)
+
+	defer first.Shutdown()
+	defer second.Shutdown()
+	defer third.Shutdown()
+
+	wg := &sync.WaitGroup{}
+
+	wg.Add(1)
+	sendBroadcast := func(unity util.Unity) {
+		defer wg.Done()
+		broadcast := util.GenerateRequest([]byte(helper.GenerateUID()), partitions)
+		err := unity.Write(broadcast)
+		if err != nil {
+			t.Errorf("failed sending message to %v. %#v", partitions, err)
+		}
+	}
+
+	go sendBroadcast(first)
+	wg.Wait()
+
+	time.Sleep(util.DefaultTestTimeout)
+	util.CompareOutputs(t, []util.Unity{first, second, third}, func(data types.DataHolder) bool {
+		return true
+	})
+}
+
+// If a correct process `p` and `q` both GM-Deliver messages `m` and `n`,
+// ({p, q} \in m.dest \inter n.dest) and Conflict(m, n), then `p` GM-Deliver
+// `m` before `n` iff `q` GM-Deliver `m` before `n`.
+func Test_PartialOrderProperty(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	partition1 := []int{16100, 16101, 16102}
+	partition2 := []int{16103, 16104, 16105}
+	partition3 := []int{16106, 16107, 16108}
+
+	partitionA := util.ProperPartitionName("partial-order-a", partition1)
+	partitionB := util.ProperPartitionName("partial-order-b", partition2)
+	partitionC := util.ProperPartitionName("partial-order-c", partition3)
+
+	first := util.CreateUnity(partitionA, partition1, t)
+	second := util.CreateUnity(partitionB, partition2, t)
+	third := util.CreateUnity(partitionC, partition3, t)
+
+	sampleSize := 10
+
+	wg := &sync.WaitGroup{}
+
+	defer first.Shutdown()
+	defer second.Shutdown()
+	defer third.Shutdown()
+
+	ab := []byte("AB")
+	bc := []byte("BC")
+	ac := []byte("AC")
+
+	sendBroadcast := func(unity util.Unity, extra []byte, partitions []types.Partition) {
+		defer wg.Done()
+		broadcast := util.GenerateRequest([]byte(helper.GenerateUID()), partitions)
+		broadcast.Extra = extra
+		err := unity.Write(broadcast)
+		if err != nil {
+			t.Errorf("failed sending message to %v. %#v", partitions, err)
+		}
+	}
+
+	wg.Add(sampleSize)
+	for i := 0; i < sampleSize; i++ {
+		go sendBroadcast(first, ab, []types.Partition{partitionA, partitionB})
+	}
+
+	wg.Add(sampleSize)
+	for i := 0; i < sampleSize; i++ {
+		go sendBroadcast(second, bc, []types.Partition{partitionB, partitionC})
+	}
+
+	wg.Add(sampleSize)
+	for i := 0; i < sampleSize; i++ {
+		go sendBroadcast(third, ac, []types.Partition{partitionA, partitionC})
+	}
+
+	wg.Add(sampleSize)
+	for i := 0; i < sampleSize; i++ {
+		go sendBroadcast(first, nil, []types.Partition{partitionA, partitionB, partitionC})
+	}
+
+	wg.Wait()
+	time.Sleep(util.DefaultTestTimeout)
+
+	util.CompareOutputs(t, []util.Unity{first, second}, func(data types.DataHolder) bool {
+		return data.Extensions == nil || bytes.Equal(data.Extensions, ab)
+	})
+
+	util.CompareOutputs(t, []util.Unity{second, third}, func(data types.DataHolder) bool {
+		return data.Extensions == nil || bytes.Equal(data.Extensions, bc)
+	})
+
+	util.CompareOutputs(t, []util.Unity{first, third}, func(data types.DataHolder) bool {
+		return data.Extensions == nil || bytes.Equal(data.Extensions, ac)
+	})
+
+	util.CompareOutputs(t, []util.Unity{first, second, third}, func(data types.DataHolder) bool {
+		return data.Extensions == nil
+	})
+}

--- a/test/protocol_test.go
+++ b/test/protocol_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"github.com/jabolina/go-mcast/pkg/mcast/types"
+	"github.com/jabolina/go-mcast/test/util"
 	"testing"
 	"time"
 )
@@ -14,8 +15,8 @@ import (
 // Then a response will be queried back from the unity state machine.
 func TestProtocol_GMCastMessageSingleUnitySingleProcess(t *testing.T) {
 	ports := []int{32200}
-	partitionName := ProperPartitionName("single.unity", ports)
-	unity := CreateUnity(partitionName, ports, t)
+	partitionName := util.ProperPartitionName("single.unity", ports)
+	unity := util.CreateUnity(partitionName, ports, t)
 	defer unity.Shutdown()
 	value := []byte("test")
 	write := types.Request{
@@ -54,10 +55,10 @@ func TestProtocol_GMCastMessageSingleUnitySingleProcess(t *testing.T) {
 func TestProtocol_GMCastMessageTwoPartitions(t *testing.T) {
 	portFirst := []int{32020}
 	portSnd := []int{32030}
-	partitionOne := ProperPartitionName("single-unity-one", portFirst)
-	partitionTwo := ProperPartitionName("single-unity-two", portSnd)
-	unityOne := CreateUnity(partitionOne, portFirst, t)
-	unityTwo := CreateUnity(partitionTwo, portSnd, t)
+	partitionOne := util.ProperPartitionName("single-unity-one", portFirst)
+	partitionTwo := util.ProperPartitionName("single-unity-two", portSnd)
+	unityOne := util.CreateUnity(partitionOne, portFirst, t)
+	unityTwo := util.CreateUnity(partitionTwo, portSnd, t)
 	defer unityOne.Shutdown()
 	defer unityTwo.Shutdown()
 	value := []byte("test")
@@ -103,10 +104,10 @@ func TestProtocol_GMCastMessageTwoPartitions(t *testing.T) {
 func TestProtocol_TwoPartitionsSingleParticipant(t *testing.T) {
 	portFst := []int{32000}
 	portSnd := []int{32010}
-	partitionOne := ProperPartitionName("a-single-unity-one", portFst)
-	partitionTwo := ProperPartitionName("b-single-unity-two", portSnd)
-	unityOne := CreateUnity(partitionOne, portFst, t)
-	unityTwo := CreateUnity(partitionTwo, portSnd, t)
+	partitionOne := util.ProperPartitionName("a-single-unity-one", portFst)
+	partitionTwo := util.ProperPartitionName("b-single-unity-two", portSnd)
+	unityOne := util.CreateUnity(partitionOne, portFst, t)
+	unityTwo := util.CreateUnity(partitionTwo, portSnd, t)
 	defer func() {
 		unityOne.Shutdown()
 		unityTwo.Shutdown()

--- a/test/util/generator.go
+++ b/test/util/generator.go
@@ -1,4 +1,4 @@
-package test
+package util
 
 import (
 	"github.com/jabolina/go-mcast/pkg/mcast/helper"

--- a/test/util/helper.go
+++ b/test/util/helper.go
@@ -1,4 +1,4 @@
-package test
+package util
 
 import "sync"
 
@@ -8,21 +8,21 @@ type MessageHist struct {
 	data    map[string]bool
 }
 
-func (m *MessageHist) insert(message string) {
+func (m *MessageHist) Insert(message string) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.history = append(m.history, message)
 	m.data[message] = true
 }
 
-func (m *MessageHist) contains(message string) bool {
+func (m *MessageHist) Contains(message string) bool {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	_, ok := m.data[message]
 	return ok
 }
 
-func (m *MessageHist) values() []string {
+func (m *MessageHist) Values() []string {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	var copied []string
@@ -30,13 +30,13 @@ func (m *MessageHist) values() []string {
 	return copied
 }
 
-func (m *MessageHist) size() int {
+func (m *MessageHist) Size() int {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	return len(m.history)
 }
 
-func (m *MessageHist) compare(other MessageHist) int {
+func (m *MessageHist) Compare(other MessageHist) int {
 	// if both objects hold the same mutex a deadlock will be created.
 	if m.mutex == other.mutex {
 		return 0
@@ -45,7 +45,7 @@ func (m *MessageHist) compare(other MessageHist) int {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	different := 0
-	for i, s := range other.values() {
+	for i, s := range other.Values() {
 		if len(m.history)-1 < i {
 			different += 1
 			continue

--- a/test/util/oracle_testing.go
+++ b/test/util/oracle_testing.go
@@ -1,4 +1,4 @@
-package test
+package util
 
 import (
 	"fmt"

--- a/test/util/testing.go
+++ b/test/util/testing.go
@@ -1,14 +1,12 @@
-package test
+package util
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/jabolina/go-mcast/pkg/mcast"
 	"github.com/jabolina/go-mcast/pkg/mcast/core"
 	"github.com/jabolina/go-mcast/pkg/mcast/definition"
 	"github.com/jabolina/go-mcast/pkg/mcast/helper"
 	"github.com/jabolina/go-mcast/pkg/mcast/types"
-	"github.com/prometheus/common/log"
 	"os"
 	"runtime"
 	"sync"
@@ -123,52 +121,6 @@ func (c *UnityCluster) Next() Unity {
 	}
 
 	return c.Unities[c.index]
-}
-
-func DoWeMatch(expected []types.DataHolder, unities []Unity, t *testing.T) {
-	for _, unity := range unities {
-		res := unity.Read()
-
-		if !res.Success {
-			t.Errorf("reading partition failed. %v", res.Failure)
-			continue
-		}
-		outputValues(res.Data, string(unity.WhoAmI()))
-
-		toVerify := onlyOrdered(res.Data)
-		for i, holder := range expected {
-			if len(toVerify)-1 < i {
-				t.Errorf("Content differ cmd %d for unity %s, expected %#v, found nothing", i, unity.WhoAmI(), holder)
-				continue
-			}
-
-			actual := toVerify[i]
-			if !bytes.Equal(holder.Content, actual.Content) {
-				t.Errorf("Content differ cmd %d for unity %s, expected %#v, found %#v", i, unity.WhoAmI(), holder, actual)
-			}
-		}
-	}
-}
-
-func (c UnityCluster) DoesClusterMatchTo(expected []types.DataHolder) {
-	DoWeMatch(expected, c.Unities, c.T)
-}
-
-func onlyOrdered(expected []types.DataHolder) []types.DataHolder {
-	var notGeneric []types.DataHolder
-	for _, holder := range expected {
-		if holder.Extensions == nil {
-			notGeneric = append(notGeneric, holder)
-		}
-	}
-	return notGeneric
-}
-
-func outputValues(values []types.DataHolder, owner string) {
-	log.Infof("--------------------%s-------------------------", owner)
-	for _, value := range values {
-		log.Infof("%s - %d - %v\n", value.Meta.Identifier, value.Meta.Timestamp, value.Extensions != nil)
-	}
 }
 
 func (c UnityCluster) DoesAllClusterMatch() {

--- a/test/util/unity.go
+++ b/test/util/unity.go
@@ -1,4 +1,4 @@
-package test
+package util
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 	"github.com/jabolina/go-mcast/pkg/mcast/types"
 )
 
-// The unity interface, responsible for interacting
+// Unity interface is responsible for interacting
 // with all the peers.
 // The unity is equivalent as a partition and holds a
 // group of peers, each one a different goroutine. When
@@ -16,7 +16,7 @@ import (
 // issued through the unity, since all peers acts
 // as a single unity.
 type Unity interface {
-	// Apply a request to the protocol.
+	// Write Apply a request to the protocol.
 	// This does not work in the request-response model,
 	// once a request is sent the method will return right
 	// away, but this does not mean that the value is already
@@ -27,10 +27,10 @@ type Unity interface {
 	// in one of the participants.
 	Write(request types.Request) error
 
-	// Query a value from the unity.
+	// Read Query a value from the unity.
 	Read() types.Response
 
-	// Start the listener.
+	// Listen Start the listener.
 	Listen() <-chan types.Response
 
 	// Shutdown the unity.
@@ -41,7 +41,7 @@ type Unity interface {
 	WhoAmI() types.Partition
 }
 
-// Concrete implementation of the Unity interface.
+// PeerUnity is the concrete implementation of the Unity interface.
 type PeerUnity struct {
 	// Hold all peers.
 	Peers []mcast.IMulticast
@@ -108,7 +108,7 @@ func (p *PeerUnity) Listen() <-chan types.Response {
 	return peer.Listen()
 }
 
-// Implements the Unity interface.
+// Shutdown Implements the Unity interface.
 func (p *PeerUnity) Shutdown() {
 	p.Finish()
 	for _, peer := range p.Peers {
@@ -117,7 +117,7 @@ func (p *PeerUnity) Shutdown() {
 	p.Invoker.Close()
 }
 
-// Implements the Unity interface.
+// WhoAmI Implements the Unity interface.
 func (p *PeerUnity) WhoAmI() types.Partition {
 	return p.Configuration.Partition
 }

--- a/test/util/validation.go
+++ b/test/util/validation.go
@@ -1,0 +1,85 @@
+package util
+
+import (
+	"bytes"
+	"github.com/jabolina/go-mcast/pkg/mcast/types"
+	"github.com/prometheus/common/log"
+	"testing"
+)
+
+func CompareOutputs(t *testing.T, unities []Unity, filter func(data types.DataHolder) bool) {
+	if len(unities) == 0 {
+		return
+	}
+
+	first := unities[0]
+	output := first.Read()
+	if !output.Success {
+		t.Errorf("failed reading output. %#v", output.Failure)
+		return
+	}
+
+	truth := filterOutput(output.Data, filter)
+	filterEntries := func(data []types.DataHolder) []types.DataHolder {
+		var res []types.DataHolder
+		for _, holder := range data {
+			if filter(holder) {
+				res = append(res, holder)
+			}
+		}
+		return res
+	}
+	DoWeMatch(truth, unities, filterEntries, t)
+}
+
+func DoWeMatch(expected []types.DataHolder, unities []Unity, filter func([]types.DataHolder) []types.DataHolder, t *testing.T) {
+	for _, unity := range unities {
+		res := unity.Read()
+
+		if !res.Success {
+			t.Errorf("reading partition failed. %v", res.Failure)
+			continue
+		}
+		outputValues(res.Data, string(unity.WhoAmI()))
+
+		toVerify := filter(res.Data)
+		for i, holder := range expected {
+			if len(toVerify)-1 < i {
+				t.Errorf("Content differ cmd %d for unity %s, expected %#v, found nothing", i, unity.WhoAmI(), holder)
+				continue
+			}
+
+			actual := toVerify[i]
+			if !bytes.Equal(holder.Content, actual.Content) {
+				t.Errorf("Content differ cmd %d for unity %s, expected %#v, found %#v", i, unity.WhoAmI(), holder, actual)
+			}
+		}
+	}
+}
+
+func (c UnityCluster) DoesClusterMatchTo(expected []types.DataHolder) {
+	DoWeMatch(expected, c.Unities, onlyOrdered, c.T)
+}
+
+func filterOutput(data []types.DataHolder, filter func(data types.DataHolder) bool) []types.DataHolder {
+	var res []types.DataHolder
+	for _, holder := range data {
+		if filter(holder) {
+			res = append(res, holder)
+		}
+	}
+	return res
+}
+
+func onlyOrdered(expected []types.DataHolder) []types.DataHolder {
+	return filterOutput(expected, func(data types.DataHolder) bool {
+		return data.Extensions == nil
+	})
+}
+
+func outputValues(values []types.DataHolder, owner string) {
+	log.Infof("--------------------%s-------------------------", owner)
+	for _, value := range values {
+		log.Infof("%s - %d - %v\n", value.Meta.Identifier, value.Meta.Timestamp, value.Extensions != nil)
+	}
+}


### PR DESCRIPTION
Improvement for current tests. Added a more robust test for the specific multicast feature
and added tests for validating the protocol properties. The property tests is too simple?
The actual properties are tested and fulfill the requirements, so everything should be fine.

The `partial-order` test, it could looks like is misleading and only verifying specific messages.
But actually is only already forcing to verify all the messages that will met the required property
of address intersection. The address will intersect between messages that were _multicasted_ to
a partition, for example, `AB` and with message that were _broadcasted_ to all partitions. So we
verify that for both partition `A` and `B` the messages were delivered in the same order.

If messages were delivered in different order, this means that the _partial order_ property is not
holding and partitions are delivering messages that conflict in arbitrary order. As long as the test
do not fail on message delivery, the _partial order_ property is safe and messages are delivered
ordered across partitions.

