### PR TITLE
[tla] Generic Multicast 1 TLA+ specification

### DIFF
--- a/tla/.gitignore
+++ b/tla/.gitignore
@@ -1,3 +1,3 @@
 *.toolbox/
 states/
-
+*.dot

--- a/tla/mcast0/mcast0.cfg
+++ b/tla/mcast0/mcast0.cfg
@@ -1,7 +1,7 @@
 CONSTANTS
     NPROCESS = 2
-    NMESSAGES = 3
-    Conflict <- ByIdConflict
+    NMESSAGES = 2
+    Conflict <- AlwaysConflict
 
 SPECIFICATION 
     Spec

--- a/tla/mcast1/mcast1.cfg
+++ b/tla/mcast1/mcast1.cfg
@@ -1,0 +1,15 @@
+CONSTANTS
+    NPARTITIONS = 2
+    NPROCESS = 2
+    NMESSAGES = 3
+    Conflict <- ByIdConflict
+
+SPECIFICATION 
+    Spec
+
+PROPERTY
+    Validity
+    Agreement
+    Integrity
+    PartialOrder
+    Collision

--- a/tla/mcast1/mcast1.cfg
+++ b/tla/mcast1/mcast1.cfg
@@ -1,8 +1,8 @@
 CONSTANTS
     NPARTITIONS = 2
     NPROCESS = 2
-    NMESSAGES = 3
-    Conflict <- ByIdConflict
+    NMESSAGES = 2
+    Conflict <- AlwaysConflict
 
 SPECIFICATION 
     Spec

--- a/tla/mcast1/mcast1.tla
+++ b/tla/mcast1/mcast1.tla
@@ -1,0 +1,209 @@
+--------------------    MODULE mcast1    --------------------
+
+EXTENDS Naturals, FiniteSets, Sequences
+
+CONSTANTS 
+    NPARTITIONS,
+    NPROCESS,
+    NMESSAGES,
+    Conflict(_,_)
+
+Processes == 1 .. NPROCESS
+Partitions == 1 .. NPARTITIONS
+
+ChoosePartition == CHOOSE pa \in SUBSET Partitions: Cardinality(pa) > 0
+Messages == [m \in 1 .. NMESSAGES |-> [id |-> m, d |-> Partitions, ts |-> 0, s |-> 0]]
+ToSend == {Messages[i] : i \in 1 .. NMESSAGES}
+OnlyIncluded(pa) == {m \in Messages: pa \in m.d}
+
+IsEven(x) == x % 2 = 0
+ByIdConflict(x, y) == IsEven(x.id) = IsEven(y.id)
+
+Max(S) == CHOOSE x \in S: \A y \in S : x >= y
+
+\* Verify the input values.
+ASSUME 
+    /\ NPARTITIONS \in (Nat \ {0})
+
+    \* Verify that `NPROCESS` is a natural number greater than 0.
+    /\ NPROCESS \in (Nat \ {0})
+
+    \* Verify that the number of messages to exchange is natural
+    \* greater than 0.
+    /\ NMESSAGES \in (Nat \ {0})
+
+VARIABLES 
+    K,
+    Mem,
+    PreviousSet,
+    ABCast,
+    Delivered,
+    Network
+
+vars == <<
+    K,
+    Mem,
+    PreviousSet,
+    Delivered,
+    ABCast,
+    Network >>
+
+--------------------------------------------------------------
+InitProtocol ==
+    /\ K = [i \in Partitions |-> [p \in Processes |-> 0]]
+    /\ Mem = [i \in Partitions |-> [p \in Processes |-> {}]]
+    /\ PreviousSet = [i \in Partitions |-> [p \in Processes |-> {}]]
+    /\ Delivered = [i \in Partitions |-> [p \in Processes |-> {}]]
+
+InitHelpers ==
+    /\ ABCast = [i \in Partitions |-> [p \in Processes |-> Messages]]
+    /\ Network = [i \in Partitions |-> [p \in Processes |-> {}]]
+
+Init == InitProtocol /\ InitHelpers
+
+ComputeGroupSeqNumber(p, q) ==
+    /\ Len(ABCast[p][q]) > 0
+    /\ LET
+        m == Head(ABCast[p][q])
+       IN
+        /\ \/ /\ \A <<i, d>> \in Delivered[p][q]: \A n \in d: n.id /= m.id
+              /\ \/ /\ m.s = 0
+                    /\ \/ /\ \E n \in PreviousSet[p][q]: Conflict(m, n)
+                          /\ K' = [K EXCEPT ![p][q] = K[p][q] + 1]
+                          /\ PreviousSet' = [PreviousSet EXCEPT ![p][q] = {m}]
+                       \/ /\ \A n \in PreviousSet[p][q]: ~Conflict(m, n)
+                          /\ PreviousSet' = [PreviousSet EXCEPT ![p][q] = PreviousSet[p][q] \cup {m}]
+                          /\ UNCHANGED K
+                 \/ /\ m.s /= 0
+              /\ \/ /\ Cardinality(m.d) > 1
+                    /\ \/ /\ m.s = 0
+                          /\ Mem' = [Mem EXCEPT ![p][q] = (@ \ {m}) \cup {[id |-> m.id, d |-> m.d, ts |-> K'[p][q], s |-> 1]}]
+                          /\ Network' = [pp \in Partitions |-> IF pp \in m.d
+                                    THEN [qq \in Processes |-> Network[pp][qq] \cup {[id |-> m.id, d |-> m.d, ts |-> K'[p][q], s |-> 1, o |-> p]}]
+                                    ELSE Network[pp]]
+                       \/ /\ m.s = 2
+                          /\ \/ /\ m.ts > K[p][q]
+                                /\ K' = [K EXCEPT ![p][q] = m.ts]
+                                /\ PreviousSet' = [PreviousSet EXCEPT ![p][q] = {}]
+                             \/ /\ m.ts <= K[p][q]
+                                /\ UNCHANGED <<K, PreviousSet>>
+                          /\ Mem' = [Mem EXCEPT ![p][q] = (@ \ {m}) \cup {[id |-> m.id, d |-> m.d, ts |-> m.ts, s |-> 3]}]
+                          /\ UNCHANGED Network
+                 \/ /\ Cardinality(m.d) = 1
+                    /\ Mem' = [Mem EXCEPT ![p][q] = (@ \ {m}) \cup {[id |-> m.id, d |-> m.d, ts |-> K'[p][q], s |-> 3]}]
+                    /\ UNCHANGED Network
+           \/ /\ \E <<i, d>> \in Delivered[p][q]: \E n \in d: n.id = m.id
+        /\ ABCast' = [ABCast EXCEPT ![p][q] = Tail(ABCast[p][q])]
+        /\ UNCHANGED Delivered
+
+GatherGroupsTimestamp(p, q) ==
+    \E m \in Mem[p][q]: 
+        /\ m.s = 1
+        /\ Cardinality(m.d) = Cardinality({v.o : v \in {x \in Network[p][q]: x.id = m.id}})
+        /\ LET
+            timestamps == {v.ts : v \in {x \in Network[p][q]: x.id = m.id}}
+            msgs == {x \in Network[p][q]: x.id = m.id}
+           IN
+            /\ \/ /\ m.ts >= Max(timestamps)
+                  /\ Mem' = [Mem EXCEPT ![p][q] = (@ \ {m}) \cup {[id |-> m.id, d |-> m.d, ts |-> m.ts, s |-> 3]}]
+                  /\ UNCHANGED <<K, PreviousSet, ABCast, Delivered>>
+               \/ /\ m.ts < Max(timestamps)
+                  /\ Mem' = [Mem EXCEPT ![p][q] = (@ \ {m}) \cup {[id |-> m.id, d |-> m.d, ts |-> Max(timestamps), s |-> 2]}]
+                  /\ ABCast' = [ABCast EXCEPT ![p] =
+                        [qq \in Processes |-> Append(ABCast[p][qq], [id |-> m.id, d |-> m.d, ts |-> Max(timestamps), s |-> 2])]]
+                  /\ UNCHANGED <<K, PreviousSet, Delivered>>
+            /\ Network' = [Network EXCEPT ![p][q] = @ \ msgs]
+
+DoDeliver(p, q) ==
+    \E m \in Mem[p][q]:
+        /\ m.s = 3
+        /\ \A n \in Mem[p][q] \ {m}:
+            /\ m.ts <= n.ts
+            /\ \/ ~Conflict(m, n)
+               \/ m.id < n.id \/ m.ts < n.ts
+        /\ LET
+            G == {mm \in Mem[p][q]: \A nn \in Mem[p][q] \ {mm}: ~Conflict(mm, nn)}
+            D == {m} \cup G
+            index == Cardinality(Delivered[p][q])
+           IN
+            /\ Mem' = [Mem EXCEPT ![p][q] = @ \ D]
+            /\ Delivered' = [Delivered EXCEPT ![p][q] = Delivered[p][q] \cup {<<index, D>>}]
+            /\ UNCHANGED <<K, PreviousSet, ABCast, Network>>
+
+--------------------------------------------------------------
+Step(pa, pr) ==
+    \/ ComputeGroupSeqNumber(pa, pr)
+    \/ GatherGroupsTimestamp(pa, pr)
+    \/ DoDeliver(pa, pr)
+
+PartitionStep(pa) ==
+    \E pr \in Processes: Step(pa, pr)
+
+Next ==
+    \/ \E self \in Partitions: PartitionStep(self)
+    \/ UNCHANGED vars
+
+Spec == Init /\ [][Next]_vars
+             /\ WF_vars(\E self \in Partitions: PartitionStep(self))
+--------------------------------------------------------------
+WasDelivered(pa, pr, m) ==
+    \E <<i, msgs>> \in Delivered[pa][pr]: \E n \in msgs: m.id = n.id
+ExistDeliver(pa, m) ==
+    \E pr \in Processes: WasDelivered(pa, pr, m)
+UnionPartitionDeliver(pa, m) ==
+    UNION {Delivered[pa][x]: x \in DOMAIN Delivered[pa]}
+DeliveredIndex(pa, m) ==
+    (CHOOSE <<i, msgs>> \in UnionPartitionDeliver(pa, m): \E n \in msgs: n.id = m.id)[1]
+
+Validity ==
+    \A m \in ToSend:
+        \E <<pa, pr>> \in Partitions \X Processes:
+                pa \in m.d ~> \E ppa \in m.d : \E ppr \in Processes: WasDelivered(ppa, ppr, m)
+
+Agreement ==
+    \A m \in ToSend:
+        \A <<pa, pr>> \in Partitions \X Processes:
+            WasDelivered(pa, pr, m) ~> \A ppa \in m.d: \E ppr \in Processes: WasDelivered(ppa, ppr, m)
+
+DeliveredOnlyOnce(pa, pr, m) == Cardinality({x \in Delivered[pa][pr]: \E n \in x[2]: n.id = m.id}) = 1
+Integrity ==
+    \A m \in ToSend:
+        \A <<pa, pr>> \in Partitions \X Processes:
+            pa \in m.d ~> \A ppa \in Partitions: 
+                            \E ppr \in Processes: 
+                                WasDelivered(ppa, ppr, m) /\ DeliveredOnlyOnce(ppa, ppr, m)
+
+
+AssertDeliveryOrder(pm, pn, qm, qn) == 
+    \/ ((pm < pn) /\ (qm < qn))
+    \/ (~(pm < pn) /\ ~(qm < qn))
+BothDelivered(pa, qa, pr, qr, m, n) ==
+    /\ WasDelivered(pa, pr, m) /\ WasDelivered(pa, pr, n)
+    /\ WasDelivered(qa, qr, m) /\ WasDelivered(qa, qr, n)
+LHS(pa, qa, m, n) ==
+    /\ {pa, qa} \subseteq (m.d \intersect n.d)
+    /\ Conflict(m, n)
+    /\ \E pr, qr \in Processes:
+        BothDelivered(pa, qa, pr, qr, m, n)
+RHS(p, q, m, n) ==
+    /\ LET
+        pm == DeliveredIndex(p, m)
+        pn == DeliveredIndex(p, n)
+        qm == DeliveredIndex(q, m)
+        qn == DeliveredIndex(q, n)
+        IN
+        AssertDeliveryOrder(pm, pn, qm, qn)
+PartialOrder ==
+    []\A m, n \in ToSend:
+        \A p, q \in Partitions:
+            LHS(p, q, m, n) => RHS(p, q, m, n)
+
+Collision ==
+    []\A p \in Partitions:
+        \A m, n \in ToSend:
+            /\ m.id /= n.id
+                /\ p \in (m.d \intersect n.d)
+                /\ ExistDeliver(p, m)
+                /\ ExistDeliver(p, n)
+                /\ Conflict(m, n) => DeliveredIndex(p, m) /= DeliveredIndex(p, n)
+==============================================================


### PR DESCRIPTION
Adding the TLA+ specification for the Generic Multicast 1
algorithm. In this specification all the processes are ``correct''
and the simple network primitive is _quasi-reliable_.

No failures are verified here yet, this could be added in
the future. Also could be nice to split the network in
modules, a module for simple network and another for
the atomic broadcast.

When adding faulty processes and network failures,
the invariant properties expressed will change. Maybe 
also adding more safety properties would be nice.